### PR TITLE
Keywords classes

### DIFF
--- a/grammars/mojom.cson
+++ b/grammars/mojom.cson
@@ -28,9 +28,9 @@
     'begin': '\\b(struct|union)\\b\\s*([_A-Za-z][_A-Za-z0-9]*)\\b'
     'beginCaptures':
       '1':
-        'name': 'storage.type.mojom'
+        'name': 'keyword.declaration.mojom'
       '2':
-        'name': 'entity.name.type.mojom'
+        'name': 'entity.type.mojom'
     'end': '(?<=\\})'
     'name': 'meta.struct-union-block.mojom'
     'patterns': [
@@ -56,9 +56,9 @@
     'begin': '\\b(interface)\\b\\s*([_A-Za-z][_A-Za-z0-9]*)\\b'
     'beginCaptures':
       '1':
-        'name': 'storage.type.mojom'
+        'name': 'keyword.declaration.mojom'
       '2':
-        'name': 'entity.name.type.mojom'
+        'name': 'entity.type.mojom'
     'end': '(?<=\\})'
     'name': 'meta.interface-block.mojom'
     'patterns': [
@@ -83,9 +83,9 @@
     'begin': '\\b(enum)\\b\\s*([_A-Za-z][_A-Za-z0-9]*)\\b'
     'beginCaptures':
       '1':
-        'name': 'storage.type.mojom'
+        'name': 'keyword.declaration.mojom'
       '2':
-        'name': 'entity.name.type.mojom'
+        'name': 'entity.type.mojom'
     'end': '(?<=\\})'
     'name': 'meta.enum-block.mojom'
     'patterns': [

--- a/settings/mojom.cson
+++ b/settings/mojom.cson
@@ -1,0 +1,3 @@
+'.source.mojom':
+  'editor':
+    'commentStart': '// '


### PR DESCRIPTION
- adjust some keyword styling and class declaration styling
- add a settings file to specify the preferred comment chars

The theme I'm using styled the class declarations with an underline. I think the textmate names you're returning are correct, but I don't know that the common themes handle them well. Here's an alternate, based on some other language files.

before:

<img width="407" alt="screen shot 2015-11-08 at 3 24 58 pm" src="https://cloud.githubusercontent.com/assets/1269969/11023455/fb438cee-862d-11e5-9420-0cc8c6e6fb8e.png">

after:

<img width="426" alt="screen shot 2015-11-08 at 3 23 57 pm" src="https://cloud.githubusercontent.com/assets/1269969/11023454/f3050904-862d-11e5-8d8f-6e24de9da34a.png">
